### PR TITLE
2.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "veil-js",
-  "version": "2.0.0-alpha.1",
+  "version": "2.0.0",
   "description": "Veil API Wrapper",
   "main": "dist/index.js",
   "author": "Veil, Inc.",

--- a/src/Veil.ts
+++ b/src/Veil.ts
@@ -306,6 +306,8 @@ export default class Veil {
     tokenType: "long" | "short",
     params: LimitOrderParams | MarketOrderParams
   ) {
+    if (params.type !== "limit" && params.type !== "market")
+      throw new Error("Type (market or limit) is required to create a quote");
     if (!this.isSetup) await this.setup();
     const token = tokenType === "long" ? market.longToken : market.shortToken;
 


### PR DESCRIPTION
This is a major version bump because it breaks backwards-compatibility of the `createQuote` method, which can now be used to create market orders in addition to limit orders.

This version also adds support for a custom Web3 provider to be used to sign orders (if you aren't into passing your mnemonic to a javascript library). Arguments to the `Veil` constructor are now passed as an object.